### PR TITLE
Implement easily actionable suggestions from Julia

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,3 +1,11 @@
 .cc-field-name {
     font-weight: bold;
 }
+
+.w-20 {
+    width: 20%;
+}
+
+.w-15 {
+    width: 15%;
+}

--- a/templates/collection.html
+++ b/templates/collection.html
@@ -16,33 +16,28 @@
 </div>
 <div class="row">
     <div class="col">
-        <p><span class="cc-field-name">{{ .descriptionPropLabel }}: </span>{{ .description }}</p>
-    </div>
-</div>
-<div class="row">
-    <div class="col">
-        <p><span class="cc-field-name">{{ .collectionTypePropLabel }}: </span>{{ .collectionTypeLabel }}</p>
-        <p><span class="cc-field-name">{{ .creatorPropLabel }}: </span>{{ safe_html .creators }}</p>
-        <p><span class="cc-field-name">{{ .donorPropLabel }}: </span>{{ safe_html .donors }}</p>
-        <br/>
+        <p>{{ .description }}</p>
+        <hr>
         <p><span class="cc-field-name">{{ .generalRecordsPropLabel }}: </span>{{ .generalRecordsTypes }}</p>
         <p><span class="cc-field-name">{{ .specificRecordsPropLabel }}: </span>{{ .specificRecordsTypes }}</p>
         <p><span class="cc-field-name">{{ .materialsStartPropLabel }}: </span>{{ .materialsStartYear }}</p>
         <p><span class="cc-field-name">{{ .materialsEndPropLabel }}: </span>{{ .materialsEndYear }}</p> 
         <p><span class="cc-field-name">{{ .subjectPropLabel }}: </span>{{ .subjects }}</p>
         <p><span class="cc-field-name">{{ .languagePropLabel }}: </span>{{ .languages }}</p>   
-        <br/>
+        <hr>
+        <p><span class="cc-field-name">{{ .officialWebsitePropLabel }}: </span><a href="{{ .officialWebsite }}">{{ .officialWebsite }}</a></p>  
+        <p><span class="cc-field-name">{{ .describedAtURLPropLabel }}: </span><a href="{{ .describedAtURL }}">{{ .describedAtURL }}</a></p> 
+        <hr>
+        <p><span class="cc-field-name">{{ .collectionTypePropLabel }}: </span>{{ .collectionTypeLabel }}</p>
+        <p><span class="cc-field-name">{{ .creatorPropLabel }}: </span>{{ safe_html .creators }}</p>
+        <p><span class="cc-field-name">{{ .donorPropLabel }}: </span>{{ safe_html .donors }}</p>
         <p><span class="cc-field-name">{{ .maintainerPropLabel }}: </span>{{ safe_html .maintainers }}</p>
         <p><span class="cc-field-name">{{ .accessStatusPropLabel }}: </span>{{ .accessStatusLabel }}</p>
         <p><span class="cc-field-name">{{ .digitizationStatusPropLabel }}: </span>{{ .digitizationStatusLabel }}</p>
         <p><span class="cc-field-name">{{ .accessPolicyPropLabel }}: </span>{{ .accessPolicy }}</p>
-        <br/>
         <p><span class="cc-field-name">{{ .projectStatusPropLabel }}: </span>{{ .projectStatus }}</p>
         <p><span class="cc-field-name">{{ .projectStartPropLabel }}: </span>{{ .projectStartYear }}</p>
         <p><span class="cc-field-name">{{ .projectEndPropLabel }}: </span>{{ .projectEndYear }}</p>
-        <br/>
-        <p><span class="cc-field-name">{{ .officialWebsitePropLabel }}: </span><a href="{{ .officialWebsite }}">{{ .officialWebsite }}</a></p>  
-        <p><span class="cc-field-name">{{ .describedAtURLPropLabel }}: </span><a href="{{ .describedAtURL }}">{{ .describedAtURL }}</a></p>           
     </div>
 </div>
 <div class="row">

--- a/templates/collections_index.html
+++ b/templates/collections_index.html
@@ -21,14 +21,16 @@
                 <tr>
                     <th>{{ (index . 0).collectionTitlePropLabel }}</th>
                     <th>{{ (index . 0).collectionTypePropLabel }}</th>
+                    <th>{{ (index . 0).digitizationStatusPropLabel }}</th>
                     <th>{{ (index . 0).descriptionPropLabel }}</th>
                 </tr>
             </thead>
             <tbody>
                 {{ range . }}
                 <tr>
-                    <td class="w-25"><a href="./{{ .qid }}.html">{{ .collectionTitle }}</a></td>
-                    <td class="w-25">{{ .collectionTypeLabel }}</td>
+                    <td class="w-20"><a href="./{{ .qid }}.html">{{ .collectionTitle }}</a></td>
+                    <td class="w-15">{{ .collectionTypeLabel }}</td>
+                    <td class="w-15">{{ .digitizationStatusLabel }}</td>
                     <td class="w-50">{{ .description }}</td>
                 </tr>
                 {{ end }}

--- a/templates/org_index.html
+++ b/templates/org_index.html
@@ -21,14 +21,16 @@
             <tr>
                 <th>{{ (index . 0).officialNamePropLabel }}</th>
                 <th>{{ (index . 0).orgTypePropLabel }}</th>
+                <th>{{ (index . 0).inceptionPropLabel }}</th>
                 <th>{{ (index . 0).streetAddressPropLabel }}</th>
             </tr>
         </thead>
         <tbody>        
             {{ range . }}
             <tr>
-                <td class="w-25"><a href="./{{ .qid }}.html">{{ .officialName }}</a></td>
-                <td class="w-25">{{ .orgTypeLabel }}</td>
+                <td class="w-20"><a href="./{{ .qid }}.html">{{ .officialName }}</a></td>
+                <td class="w-15">{{ .orgTypeLabel }}</td>
+                <td class="w-15">{{ .inceptionYear }}</td>
                 <td class="w-50">{{ .streetAddress }}</td>
             </tr>
             {{ end }}


### PR DESCRIPTION
Add digitization status to collection index, add inception date to organization index, reorder fields on individual collection pages and add clearer visual separation between chunks

Does not address any suggestions that would involve adding non-automatically generated text to templates, as those would require changing how the index and item view templates are handled wrt English/Chinese switching