### PR TITLE
Query readability

### DIFF
--- a/queries/en_collections-by-maintainer.rq
+++ b/queries/en_collections-by-maintainer.rq
@@ -1,12 +1,12 @@
 SELECT DISTINCT ?qid ?collectionLabel WHERE {
   # variables used in query
   BIND(wdt:P7 AS ?instanceOf).
-  BIND(wdt:P11 AS ?maintainedBy)
+  BIND(wdt:P11 AS ?hasMaintainer).
   BIND(wd:Q85 AS ?ChinatownCollection).
   BIND("http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/" AS ?baseURI).
 
   ?collection ?instanceOf ?ChinatownCollection;
-               ?maintainedBy wd:{{.}}.
+               ?hasMaintainer wd:{{.}}.
   SERVICE wikibase:label { bd:serviceParam wikibase:language "en" }
   BIND(REPLACE(STR(?collection), ?baseURI, "") AS ?qid)
 } ORDER BY ?collectionLabel

--- a/queries/en_collections-by-maintainer.rq
+++ b/queries/en_collections-by-maintainer.rq
@@ -1,6 +1,12 @@
 SELECT DISTINCT ?qid ?collectionLabel WHERE {
-  ?collection wdt:P7 wd:Q85;
-               wdt:P11 wd:{{.}}.
+  # variables used in query
+  BIND(wdt:P7 AS ?instanceOf).
+  BIND(wdt:P11 AS ?maintainedBy)
+  BIND(wd:Q85 AS ?ChinatownCollection).
+  BIND("http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/" AS ?baseURI).
+
+  ?collection ?instanceOf ?ChinatownCollection;
+               ?maintainedBy wd:{{.}}.
   SERVICE wikibase:label { bd:serviceParam wikibase:language "en" }
-  BIND(REPLACE(STR(?collection), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?qid)
+  BIND(REPLACE(STR(?collection), ?baseURI, "") AS ?qid)
 } ORDER BY ?collectionLabel

--- a/queries/en_collections-by-material.rq
+++ b/queries/en_collections-by-material.rq
@@ -1,12 +1,12 @@
 SELECT DISTINCT ?qid ?collectionLabel WHERE {
   # variables used in query
    BIND(wdt:P7 AS ?instanceOf).
-   BIND(wdt:P38 AS ?containsMaterial)
+   BIND(wdt:P38 AS ?hasMaterial).
    BIND(wd:Q85 AS ?ChinatownCollection).
    BIND("http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/" AS ?baseURI).
 
   ?collection ?instanceOf ?ChinatownCollection;
-              ?containsMaterial wd:{{.}}.
+              ?hasMaterial wd:{{.}}.
   SERVICE wikibase:label { bd:serviceParam wikibase:language "en" }
   BIND(REPLACE(STR(?collection), ?baseURI, "") AS ?qid)
 } ORDER BY ?collectionLabel

--- a/queries/en_collections-by-material.rq
+++ b/queries/en_collections-by-material.rq
@@ -1,6 +1,12 @@
 SELECT DISTINCT ?qid ?collectionLabel WHERE {
-  ?collection wdt:P7 wd:Q85;
-               wdt:P38 wd:{{.}}.
+  # variables used in query
+   BIND(wdt:P7 AS ?instanceOf).
+   BIND(wdt:P38 AS ?containsMaterial)
+   BIND(wd:Q85 AS ?ChinatownCollection).
+   BIND("http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/" AS ?baseURI).
+
+  ?collection ?instanceOf ?ChinatownCollection;
+              ?containsMaterial wd:{{.}}.
   SERVICE wikibase:label { bd:serviceParam wikibase:language "en" }
-  BIND(REPLACE(STR(?collection), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?qid)
+  BIND(REPLACE(STR(?collection), ?baseURI, "") AS ?qid)
 } ORDER BY ?collectionLabel

--- a/queries/en_collections-by-subject.rq
+++ b/queries/en_collections-by-subject.rq
@@ -1,6 +1,12 @@
 SELECT DISTINCT ?qid ?collectionLabel WHERE {
-  ?collection wdt:P7 wd:Q85;
-               wdt:P23 wd:{{.}}.
+   # variables used in query
+   BIND(wdt:P7 AS ?instanceOf).
+   BIND(wdt:P23 AS ?hasSubject)
+   BIND(wd:Q85 AS ?ChinatownCollection).
+   BIND("http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/" AS ?baseURI)
+
+  ?collection ?instanceOf ?ChinatownCollection;
+              ?hasSubject wd:{{.}}.
   SERVICE wikibase:label { bd:serviceParam wikibase:language "en" }
-  BIND(REPLACE(STR(?collection), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?qid)
+  BIND(REPLACE(STR(?collection), ?baseURI, "") AS ?qid)
 } ORDER BY ?collectionLabel

--- a/queries/en_collections-by-subject.rq
+++ b/queries/en_collections-by-subject.rq
@@ -1,7 +1,7 @@
 SELECT DISTINCT ?qid ?collectionLabel WHERE {
    # variables used in query
    BIND(wdt:P7 AS ?instanceOf).
-   BIND(wdt:P23 AS ?hasSubject)
+   BIND(wdt:P23 AS ?hasSubject).
    BIND(wd:Q85 AS ?ChinatownCollection).
    BIND("http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/" AS ?baseURI)
 

--- a/queries/en_collections.rq
+++ b/queries/en_collections.rq
@@ -1,4 +1,4 @@
-SELECT DISTINCT ?langCode ?title ?qid ?collectionLabel 
+SELECT DISTINCT ?langCode ?qid ?collectionLabel 
 ?collectionTypePropLabel ?collectionTypeLabel ?description ?descriptionPropLabel ?wdItemPropLabel ?wdItem ?describedAtURLPropLabel 
 ?describedAtURL ?officialWebsitePropLabel ?officialWebsite ?creatorPropLabel ?creators ?maintainerPropLabel ?maintainers
 ?materialsStartPropLabel ?materialsEndPropLabel (YEAR(?materialsStart) as ?materialsStartYear) (YEAR(?materialsEnd) as ?materialsEndYear)
@@ -9,27 +9,56 @@ SELECT DISTINCT ?langCode ?title ?qid ?collectionLabel
 ?projectStartPropLabel ?projectEndPropLabel (YEAR(?projectStart) as ?projectStartYear) (YEAR(?projectEnd) as ?projectEndYear)
 ?donors ?donorPropLabel
 WHERE {
-   ?collection wdt:P7 wd:Q85;
-               wdt:P27 ?collectionTitle.
-   BIND("Collections" as ?title).
-   BIND("en" as ?langCode).
-   BIND(REPLACE(STR(?collection), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?qid).
-   OPTIONAL{?collection wdt:P50 ?collectionType.}
-   OPTIONAL{?collection wdt:P37 ?description.
-            FILTER(LANG(?description) = "en").}
-   OPTIONAL{?collection wdt:P33 ?wdItem.}
-   OPTIONAL{?collection wdt:P17 ?describedAtURL.}
-   OPTIONAL{?collection wdt:P22 ?officialWebsite.}
-   OPTIONAL{?collection wdt:P30 ?materialsStart.}
-   OPTIONAL{?collection wdt:P31 ?materialsEnd.}
-   OPTIONAL{?collection wdt:P40 ?digitizationStatus.}
-   OPTIONAL{?collection wdt:P32 ?accessStatus.}
-   OPTIONAL{?collection wdt:P41 ?accessPolicy.
-            FILTER(LANG(?accessPolicy) = "en").}
-   OPTIONAL{?collection wdt:P42 ?projectStatus.
-            FILTER(LANG(?projectStatus) = "en").}
-   OPTIONAL{?collection wdt:P43 ?projectStart.}
-   OPTIONAL{?collection wdt:P44 ?projectEnd.}
+  # variables used in query
+  BIND(wdt:P7 AS ?instanceOf).
+  BIND(wdt:P27 AS ?hasTitle).
+  BIND(wdt:P50 AS ?hasCollectionType).
+  BIND(wdt:P37 AS ?hasDescription).
+  BIND(wdt:P33 AS ?hasWikidataItem).
+  BIND(wdt:P17 AS ?hasDescriptionSite).
+  BIND(wdt:P22 AS ?hasWebsite).
+  BIND(wdt:P30 AS ?hasMaterialsStartDate).
+  BIND(wdt:P31 AS ?hasMaterialsEndDate).
+  BIND(wdt:P40 AS ?hasDigitizationStatus).
+  BIND(wdt:P32 AS ?hasAccessStatus).
+  BIND(wdt:P41 AS ?hasAccessPolicy).
+  BIND(wdt:P42 AS ?hasProjectStatus)
+  BIND(wdt:P43 AS ?hasProjectStartDate).
+  BIND(wdt:P44 AS ?hasProjectEndDate).
+  BIND(wdt:P28 AS ?hasCreator).
+  BIND(wdt:P11 AS ?hasMaintainer).
+  BIND(wdt:P38 AS ?hasGeneralRecordsType).
+  BIND(wdt:P48 AS ?hasSpecificRecordsType).
+  BIND(wdt:P23 AS ?hasSubject).
+  BIND(wdt:P13 AS ?hasLanguage).
+  BIND(wdt:P24 AS ?hasDonor).
+
+  BIND(wd:Q85 AS ?ChinatownCollection).
+  BIND("en" as ?langCode).
+  BIND("http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/" AS ?baseURI).
+
+  ?collection ?instanceOf ?ChinatownCollection;
+              ?hasTitle ?collectionTitle.
+
+  FILTER(LANG(?collectionTitle) = ?langCode).
+   
+  BIND(REPLACE(STR(?collection), ?baseURI, "") AS ?qid).
+  OPTIONAL{?collection ?hasCollectionType ?collectionType.}
+  OPTIONAL{?collection ?hasDescription ?description.
+          FILTER(LANG(?description) = ?langCode).}
+  OPTIONAL{?collection ?hasWikidataItem ?wdItem.}
+  OPTIONAL{?collection ?hasDescriptionSite ?describedAtURL.}
+  OPTIONAL{?collection ?hasWebsite ?officialWebsite.}
+  OPTIONAL{?collection ?hasMaterialsStartDate ?materialsStart.}
+  OPTIONAL{?collection ?hasMaterialsEndDate ?materialsEnd.}
+  OPTIONAL{?collection ?hasDigitizationStatus ?digitizationStatus.}
+  OPTIONAL{?collection ?hasAccessStatus ?accessStatus.}
+  OPTIONAL{?collection ?hasAccessPolicy ?accessPolicy.
+            FILTER(LANG(?accessPolicy) = ?langCode).}
+   OPTIONAL{?collection ?hasProjectStatus ?projectStatus.
+            FILTER(LANG(?projectStatus) = ?langCode).}
+   OPTIONAL{?collection ?hasProjectStartDate ?projectStart.}
+   OPTIONAL{?collection ?hasProjectEndDate ?projectEnd.}
    SERVICE wikibase:label { bd:serviceParam wikibase:language "en". 
       ?collection rdfs:label ?collectionLabel.
       ?collectionTitleProp rdfs:label ?collectionTitlePropLabel.
@@ -57,69 +86,69 @@ WHERE {
       ?projectEndProp rdfs:label ?projectEndPropLabel.
       ?donorProp rdfs:label ?donorPropLabel.
    }
-   ?wdItemProp wikibase:directClaim wdt:P33.
-   ?describedAtURLProp wikibase:directClaim wdt:P17.
-   ?officialWebsiteProp wikibase:directClaim wdt:P22.
-   ?creatorProp wikibase:directClaim wdt:P28.
-   ?maintainerProp wikibase:directClaim wdt:P11.
-   ?materialsStartProp wikibase:directClaim wdt:P30.
-   ?materialsEndProp wikibase:directClaim wdt:P31.
-   ?descriptionProp wikibase:directClaim wdt:P37.
-   ?collectionTypeProp wikibase:directClaim wdt:P50.
-   ?digitizationStatusProp wikibase:directClaim wdt:P40.
-   ?accessStatusProp wikibase:directClaim wdt:P32.
-   ?generalRecordsProp wikibase:directClaim wdt:P38.
-   ?specificRecordsProp wikibase:directClaim wdt:P48.
-   ?subjectProp wikibase:directClaim wdt:P23.
-   ?languageProp wikibase:directClaim wdt:P13.
-   ?collectionTitleProp wikibase:directClaim wdt:P27.
-   ?accessPolicyProp wikibase:directClaim wdt:P41.
-   ?projectStatusProp wikibase:directClaim wdt:P42.
-   ?projectStartProp wikibase:directClaim wdt:P43.
-   ?projectEndProp wikibase:directClaim wdt:P44.
-   ?donorProp wikibase:directClaim wdt:P24.
-   FILTER(LANG(?collectionTitle) = "en").
-   {
-     SELECT ?innerCollection 
-            (group_concat(distinct ?generalRecordsLabel; separator="; ") as ?generalRecordsTypes)
-            (group_concat(distinct ?specificRecordsLabel; separator="; ") as ?specificRecordsTypes)
-            (group_concat(distinct ?subjectLabel; separator="; ") as ?subjects)
-            (group_concat(distinct ?languageLabel; separator="; ") as ?languages)
-            (group_concat(distinct ?creatorLink; separator="; ") as ?creators)
-            (group_concat(distinct ?maintainerLink; separator="; ") as ?maintainers)
-            (group_concat(distinct ?donorLink; separator="; ") as ?donors)
-     WHERE {
-       ?innerCollection wdt:P7 wd:Q85.
-       OPTIONAL{?innerCollection wdt:P38 ?generalRecords}
-       OPTIONAL{?innerCollection wdt:P48 ?specificRecords}
-       OPTIONAL{?innerCollection wdt:P23 ?subject}
-       OPTIONAL{?innerCollection wdt:P13 ?language}
-       OPTIONAL{?innerCollection wdt:P28 ?creator.
-         BIND(REPLACE(STR(?creator), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?creatorQid).
-         ?creator rdfs:label ?creatorLabel.
-         FILTER(LANG(?creatorLabel) = "en").
-         BIND(CONCAT("<a href='./", STR(?creatorQid), ".html'>", STR(?creatorLabel), "</a>") AS ?creatorLink).
-       }
-       OPTIONAL{?innerCollection wdt:P11 ?maintainer.
-        BIND(REPLACE(STR(?maintainer), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?maintainerQid).
-        ?maintainer rdfs:label ?maintainerLabel.
-        FILTER(LANG(?maintainerLabel) = "en").
-        BIND(CONCAT("<a href='./", STR(?maintainerQid), ".html'>", STR(?maintainerLabel), "</a>") AS ?maintainerLink).
-       }
-       OPTIONAL{?innerCollection wdt:P24 ?donor.
-        BIND(REPLACE(STR(?donor), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?donorQid).
-        ?donor rdfs:label ?donorLabel.
-        FILTER(LANG(?donorLabel) = "en").
-        BIND(CONCAT("<a href='./", STR(?donorQid), ".html'>", STR(?donorLabel), "</a>") AS ?donorLink).
-       }
-       SERVICE wikibase:label { bd:serviceParam wikibase:language "en". 
-          ?generalRecords rdfs:label ?generalRecordsLabel.
-          ?specificRecords rdfs:label ?specificRecordsLabel. 
-          ?subject rdfs:label ?subjectLabel.
-          ?language rdfs:label ?languageLabel.            
-       }
+  ?collectionTitleProp wikibase:directClaim ?hasTitle.
+  ?collectionTypeProp wikibase:directClaim ?hasCollectionType.
+  ?descriptionProp wikibase:directClaim ?hasDescription.
+  ?wdItemProp wikibase:directClaim ?hasWikidataItem.
+  ?describedAtURLProp wikibase:directClaim ?hasDescriptionSite.
+  ?officialWebsiteProp wikibase:directClaim ?hasWebsite.
+  ?materialsStartProp wikibase:directClaim ?hasMaterialsStartDate.
+  ?materialsEndProp wikibase:directClaim ?hasMaterialsEndDate.
+  ?digitizationStatusProp wikibase:directClaim ?hasDigitizationStatus.
+  ?accessStatusProp wikibase:directClaim ?hasAccessStatus.
+  ?accessPolicyProp wikibase:directClaim ?hasAccessPolicy.
+  ?projectStatusProp wikibase:directClaim ?hasProjectStatus.
+  ?projectStartProp wikibase:directClaim ?hasProjectStartDate.
+  ?projectEndProp wikibase:directClaim ?hasProjectEndDate.
+  ?creatorProp wikibase:directClaim ?hasCreator.
+  ?maintainerProp wikibase:directClaim ?hasMaintainer. 
+  ?generalRecordsProp wikibase:directClaim ?hasGeneralRecordsType.
+  ?specificRecordsProp wikibase:directClaim ?hasSpecificRecordsType.
+  ?subjectProp wikibase:directClaim ?hasSubject.
+  ?languageProp wikibase:directClaim ?hasLanguage.
+  ?donorProp wikibase:directClaim ?hasDonor.
+   
+  {
+    SELECT ?innerCollection 
+          (group_concat(distinct ?generalRecordsLabel; separator="; ") as ?generalRecordsTypes)
+          (group_concat(distinct ?specificRecordsLabel; separator="; ") as ?specificRecordsTypes)
+          (group_concat(distinct ?subjectLabel; separator="; ") as ?subjects)
+          (group_concat(distinct ?languageLabel; separator="; ") as ?languages)
+          (group_concat(distinct ?creatorLink; separator="; ") as ?creators)
+          (group_concat(distinct ?maintainerLink; separator="; ") as ?maintainers)
+          (group_concat(distinct ?donorLink; separator="; ") as ?donors)
+    WHERE {
+      ?innerCollection wdt:P7 wd:Q85.
+      OPTIONAL{?innerCollection wdt:P38 ?generalRecords}
+      OPTIONAL{?innerCollection wdt:P48 ?specificRecords}
+      OPTIONAL{?innerCollection wdt:P23 ?subject}
+      OPTIONAL{?innerCollection wdt:P13 ?language}
+      OPTIONAL{?innerCollection wdt:P28 ?creator.
+        BIND(REPLACE(STR(?creator), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?creatorQid).
+        ?creator rdfs:label ?creatorLabel.
+        FILTER(LANG(?creatorLabel) = "en").
+        BIND(CONCAT("<a href='./", STR(?creatorQid), ".html'>", STR(?creatorLabel), "</a>") AS ?creatorLink).
       }
-     GROUP BY ?innerCollection
+      OPTIONAL{?innerCollection wdt:P11 ?maintainer.
+      BIND(REPLACE(STR(?maintainer), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?maintainerQid).
+      ?maintainer rdfs:label ?maintainerLabel.
+      FILTER(LANG(?maintainerLabel) = "en").
+      BIND(CONCAT("<a href='./", STR(?maintainerQid), ".html'>", STR(?maintainerLabel), "</a>") AS ?maintainerLink).
+      }
+      OPTIONAL{?innerCollection wdt:P24 ?donor.
+      BIND(REPLACE(STR(?donor), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?donorQid).
+      ?donor rdfs:label ?donorLabel.
+      FILTER(LANG(?donorLabel) = "en").
+      BIND(CONCAT("<a href='./", STR(?donorQid), ".html'>", STR(?donorLabel), "</a>") AS ?donorLink).
+      }
+      SERVICE wikibase:label { bd:serviceParam wikibase:language "en". 
+        ?generalRecords rdfs:label ?generalRecordsLabel.
+        ?specificRecords rdfs:label ?specificRecordsLabel. 
+        ?subject rdfs:label ?subjectLabel.
+        ?language rdfs:label ?languageLabel.            
+      }
     }
-  FILTER(?innerCollection = ?collection)
+    GROUP BY ?innerCollection
+  }
+FILTER(?innerCollection = ?collection)
 } ORDER BY (?collectionLabel)

--- a/queries/en_maintainers.rq
+++ b/queries/en_maintainers.rq
@@ -1,7 +1,13 @@
 SELECT ?qid ?maintainerLabel (COUNT(?collection) AS ?count)
 WHERE {
-   ?collection wdt:P7 wd:Q85;
-               wdt:P11 ?maintainer.
+   # properties used in query
+   BIND(wdt:P7 AS ?instanceOf).
+   BIND(wdt:P11 AS ?maintainedBy)
+   # items used in query
+   BIND(wd:Q85 AS ?ChinatownCollection).
+
+   ?collection ?instanceOf ?ChinatownCollection;
+               ?maintainedBy ?maintainer.
    BIND(REPLACE(STR(?maintainer), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?qid).
    SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
 } GROUP BY ?qid ?maintainerLabel ORDER BY DESC(?count)

--- a/queries/en_maintainers.rq
+++ b/queries/en_maintainers.rq
@@ -1,13 +1,13 @@
 SELECT ?qid ?maintainerLabel (COUNT(?collection) AS ?count)
 WHERE {
-   # properties used in query
+   # variables used in query
    BIND(wdt:P7 AS ?instanceOf).
    BIND(wdt:P11 AS ?maintainedBy)
-   # items used in query
    BIND(wd:Q85 AS ?ChinatownCollection).
+   BIND("http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/" AS ?baseURI).
 
    ?collection ?instanceOf ?ChinatownCollection;
                ?maintainedBy ?maintainer.
-   BIND(REPLACE(STR(?maintainer), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?qid).
+   BIND(REPLACE(STR(?maintainer), ?baseURI, "") AS ?qid).
    SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
 } GROUP BY ?qid ?maintainerLabel ORDER BY DESC(?count)

--- a/queries/en_maintainers.rq
+++ b/queries/en_maintainers.rq
@@ -2,12 +2,12 @@ SELECT ?qid ?maintainerLabel (COUNT(?collection) AS ?count)
 WHERE {
    # variables used in query
    BIND(wdt:P7 AS ?instanceOf).
-   BIND(wdt:P11 AS ?maintainedBy)
+   BIND(wdt:P11 AS ?hasMaintainer).
    BIND(wd:Q85 AS ?ChinatownCollection).
    BIND("http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/" AS ?baseURI).
 
    ?collection ?instanceOf ?ChinatownCollection;
-               ?maintainedBy ?maintainer.
+               ?hasMaintainer ?maintainer.
    BIND(REPLACE(STR(?maintainer), ?baseURI, "") AS ?qid).
    SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
 } GROUP BY ?qid ?maintainerLabel ORDER BY DESC(?count)

--- a/queries/en_materials.rq
+++ b/queries/en_materials.rq
@@ -1,13 +1,13 @@
 SELECT ?qid ?materialLabel (COUNT(?collection) AS ?count)
 WHERE {
-   # properties used in query
+   # variables used in query
    BIND(wdt:P7 AS ?instanceOf).
    BIND(wdt:P38 AS ?containsMaterial)
-   # items used in query
    BIND(wd:Q85 AS ?ChinatownCollection).
+   BIND("http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/" AS ?baseURI).
 
    ?collection ?instanceOf ?ChinatownCollection;
                ?containsMaterial ?material.
-   BIND(REPLACE(STR(?material), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?qid).
+   BIND(REPLACE(STR(?material), ?baseURI, "") AS ?qid).
    SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
 } GROUP BY ?qid ?materialLabel ORDER BY DESC(?count)

--- a/queries/en_materials.rq
+++ b/queries/en_materials.rq
@@ -2,12 +2,12 @@ SELECT ?qid ?materialLabel (COUNT(?collection) AS ?count)
 WHERE {
    # variables used in query
    BIND(wdt:P7 AS ?instanceOf).
-   BIND(wdt:P38 AS ?containsMaterial)
+   BIND(wdt:P38 AS ?hasMaterial).
    BIND(wd:Q85 AS ?ChinatownCollection).
    BIND("http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/" AS ?baseURI).
 
    ?collection ?instanceOf ?ChinatownCollection;
-               ?containsMaterial ?material.
+               ?hasMaterial ?material.
    BIND(REPLACE(STR(?material), ?baseURI, "") AS ?qid).
    SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
 } GROUP BY ?qid ?materialLabel ORDER BY DESC(?count)

--- a/queries/en_materials.rq
+++ b/queries/en_materials.rq
@@ -1,7 +1,13 @@
 SELECT ?qid ?materialLabel (COUNT(?collection) AS ?count)
 WHERE {
-   ?collection wdt:P7 wd:Q85;
-               wdt:P38 ?material.
+   # properties used in query
+   BIND(wdt:P7 AS ?instanceOf).
+   BIND(wdt:P38 AS ?containsMaterial)
+   # items used in query
+   BIND(wd:Q85 AS ?ChinatownCollection).
+
+   ?collection ?instanceOf ?ChinatownCollection;
+               ?containsMaterial ?material.
    BIND(REPLACE(STR(?material), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?qid).
    SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
 } GROUP BY ?qid ?materialLabel ORDER BY DESC(?count)

--- a/queries/en_organizations.rq
+++ b/queries/en_organizations.rq
@@ -1,29 +1,48 @@
-SELECT ?langCode ?title ?qid ?organizationLabel ?description ?wdItemPropLabel ?wdItem 
+SELECT ?langCode ?qid ?organizationLabel ?description ?wdItemPropLabel ?wdItem 
 ?officialWebsitePropLabel ?officialWebsite ?orgTypePropLabel ?orgTypeLabel 
 ?streetAddress ?streetAddressPropLabel (year(?inception) as ?inceptionYear) ?inceptionPropLabel  
 ?phoneNumber ?phoneNumberPropLabel ?emailAddress ?emailAddressPropLabel ?officialName ?officialNamePropLabel
 WHERE {
-   ?organization wdt:P7 wd:Q59;
-                 wdt:P26 ?officialName.
-   BIND("Organizations" as ?title).
+   # variables used in query
+   BIND(wdt:P7 AS ?instanceOf).
+   BIND(wdt:P26 AS ?hasOfficialName).
+   BIND(wdt:P37 AS ?hasDescription).
+   BIND(wdt:P51 AS ?hasType).
+   BIND(wdt:P33 AS ?hasWikidataItem).
+   BIND(wdt:P22 AS ?hasWebsite).
+   BIND(wdt:P29 AS ?hasStreetAddress).
+   BIND(wdt:P19 AS ?hasInceptionDate).
+   BIND(wdt:P25 AS ?hasPhoneNumber).
+   BIND(wdt:P16 AS ?hasEmail).
+
+   BIND(wd:Q59 AS ?organizationClass).
+
    BIND("en" as ?langCode).
-   BIND(REPLACE(STR(?organization), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?qid).
-   OPTIONAL{?organization wdt:P37 ?description.}
-   OPTIONAL{?organization wdt:P51 ?orgType.}
-   OPTIONAL{?organization wdt:P33 ?wdItem.}
-   OPTIONAL{?organization wdt:P22 ?officialWebsite.}
-   OPTIONAL{?organization wdt:P29 ?streetAddress.}
-   OPTIONAL{?organization wdt:P19 ?inception.} 
-   OPTIONAL{?organization wdt:P25 ?phoneNumber.}
-   OPTIONAL{?organization wdt:P16 ?emailAddress.}
-   SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
-   ?wdItemProp wikibase:directClaim wdt:P33.
-   ?officialWebsiteProp wikibase:directClaim wdt:P22.
-   ?orgTypeProp wikibase:directClaim wdt:P51.
-   ?streetAddressProp wikibase:directClaim wdt:P29. 
-   ?inceptionProp wikibase:directClaim wdt:P19.
-   ?phoneNumberProp wikibase:directClaim wdt:P25.
-   ?emailAddressProp wikibase:directClaim wdt:P16.
-   ?officialNameProp wikibase:directClaim wdt:P26.
-   FILTER(LANG(?officialName) = "en").
+   BIND("http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/" AS ?baseURI).
+
+   ?organization ?instanceOf ?organizationClass;
+                 ?hasOfficialName ?officialName.
+   FILTER(LANG(?officialName) = ?langCode).
+
+   BIND(REPLACE(STR(?organization), ?baseURI, "") AS ?qid).
+
+   OPTIONAL{?organization ?hasDescription ?description.}
+   OPTIONAL{?organization ?hasType ?orgType.}
+   OPTIONAL{?organization ?hasWikidataItem ?wdItem.}
+   OPTIONAL{?organization ?hasWebsite ?officialWebsite.}
+   OPTIONAL{?organization ?hasStreetAddress ?streetAddress.}
+   OPTIONAL{?organization ?hasInceptionDate ?inception.} 
+   OPTIONAL{?organization ?hasPhoneNumber ?phoneNumber.}
+   OPTIONAL{?organization ?hasEmail ?emailAddress.}
+
+   ?officialNameProp wikibase:directClaim ?hasOfficialName.
+   ?orgTypeProp wikibase:directClaim ?hasType.
+   ?wdItemProp wikibase:directClaim ?hasWikidataItem.
+   ?officialWebsiteProp wikibase:directClaim ?hasWebsite.
+   ?streetAddressProp wikibase:directClaim ?hasStreetAddress. 
+   ?inceptionProp wikibase:directClaim ?hasInceptionDate.
+   ?phoneNumberProp wikibase:directClaim ?hasPhoneNumber.
+   ?emailAddressProp wikibase:directClaim ?hasEmail.
+   
+   SERVICE wikibase:label { bd:serviceParam wikibase:language "en". } 
 } ORDER BY (?organizationLabel)

--- a/queries/en_people.rq
+++ b/queries/en_people.rq
@@ -1,12 +1,42 @@
-SELECT ?langCode ?title ?qid ?personLabel ?personDescription ?createdCollections ?foundedOrganizations ?maintainsCollections ?donatedCollections
+SELECT ?langCode ?qid ?personLabel ?personDescription ?createdCollections ?foundedOrganizations ?maintainsCollections ?donatedCollections
 ?donorPropLabel ?creatorPropLabel ?maintainerPropLabel ?founderPropLabel
 ?name ?namePropLabel ?officialWebsite ?officialWebsitePropLabel ?emailAddress ?emailAddressPropLabel
 WHERE {
-   ?person wdt:P7 wd:Q21;
-        wdt:P76 ?name.
-   BIND("People" as ?title).
+   # variables used in query
+   BIND(wdt:P7 AS ?instanceOf).
+   BIND(wdt:P76 AS ?hasName).
+   BIND(wdt:P24 AS ?donated).
+   BIND(wdt:P28 AS ?created).
+   BIND(wdt:P11 AS ?maintains).
+   BIND(wdt:P10 AS ?founded).
+   BIND(wdt:P76 AS ?named).
+   BIND(wdt:P22 AS ?hasWebsite).
+   BIND(wdt:P16 AS ?hasEmail).
+   BIND(wd:Q21 AS ?human).
    BIND("en" as ?langCode).
-   BIND(REPLACE(STR(?person), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?qid).
+   BIND("http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/" AS ?baseURI)
+
+   ?person ?instanceOf ?human;
+        ?hasName ?name.
+   FILTER(LANG(?name) = ?langCode).
+   
+   BIND(REPLACE(STR(?person), ?baseURI, "") AS ?qid).
+
+   OPTIONAL{?person ?hasWebsite ?officialWebsite.}
+   OPTIONAL{?person ?hasEmail ?emailAddress.}
+   OPTIONAL{
+        ?person schema:description ?personDescription.
+        FILTER(LANG(?personDescription) = ?langCode).
+   }
+
+   ?donorProp wikibase:directClaim ?donated.
+   ?creatorProp wikibase:directClaim ?created.
+   ?maintainerProp wikibase:directClaim ?maintains.
+   ?founderProp wikibase:directClaim ?founded.
+   ?nameProp wikibase:directClaim ?named.
+   ?officialWebsiteProp wikibase:directClaim ?hasWebsite.
+   ?emailAddressProp wikibase:directClaim ?hasEmail.
+
    SERVICE wikibase:label { bd:serviceParam wikibase:language "en". 
      ?person rdfs:label ?personLabel.
      ?donorProp rdfs:label ?donorPropLabel.
@@ -15,21 +45,9 @@ WHERE {
      ?founderProp rdfs:label ?founderPropLabel.
      ?nameProp rdfs:label ?namePropLabel.
      ?officialWebsiteProp rdfs:label ?officialWebsitePropLabel.
-     ?emailAddressProp rdfs:label ?emailAddressPropLabel.}
-   ?donorProp wikibase:directClaim wdt:P24.
-   ?creatorProp wikibase:directClaim wdt:P28.
-   ?maintainerProp wikibase:directClaim wdt:P11.
-   ?founderProp wikibase:directClaim wdt:P10.
-   ?nameProp wikibase:directClaim wdt:P76.
-   ?officialWebsiteProp wikibase:directClaim wdt:P22.
-   ?emailAddressProp wikibase:directClaim wdt:P16.
-   FILTER(LANG(?name) = "en").
-   OPTIONAL{
-        ?person schema:description ?personDescription.
-        FILTER(LANG(?personDescription) = "en").
+     ?emailAddressProp rdfs:label ?emailAddressPropLabel.
    }
-   OPTIONAL{?person wdt:P22 ?officialWebsite.}
-   OPTIONAL{?person wdt:P16 ?emailAddress.}
+     
    {
      SELECT ?innerPerson
             (group_concat(distinct ?createdCollectionLink; separator="; ") as ?createdCollections)
@@ -37,7 +55,7 @@ WHERE {
             (group_concat(distinct ?maintainsCollectionLink; separator="; ") as ?maintainsCollections)
             (group_concat(distinct ?donatedCollectionLink; separator="; ") as ?donatedCollections)
      WHERE {
-       ?innerPerson wdt:P7 wd:Q21.
+       ?innerPerson ?instanceOf ?human.
        OPTIONAL{?innerPerson ^wdt:P28 ?createdCollection.
                BIND(REPLACE(STR(?createdCollection), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?createdCollectionQid).
                ?createdCollection rdfs:label ?createdCollectionLabel.

--- a/queries/en_people.rq
+++ b/queries/en_people.rq
@@ -9,7 +9,6 @@ WHERE {
    BIND(wdt:P28 AS ?created).
    BIND(wdt:P11 AS ?maintains).
    BIND(wdt:P10 AS ?founded).
-   BIND(wdt:P76 AS ?named).
    BIND(wdt:P22 AS ?hasWebsite).
    BIND(wdt:P16 AS ?hasEmail).
    BIND(wd:Q21 AS ?human).
@@ -33,7 +32,7 @@ WHERE {
    ?creatorProp wikibase:directClaim ?created.
    ?maintainerProp wikibase:directClaim ?maintains.
    ?founderProp wikibase:directClaim ?founded.
-   ?nameProp wikibase:directClaim ?named.
+   ?nameProp wikibase:directClaim ?hasName.
    ?officialWebsiteProp wikibase:directClaim ?hasWebsite.
    ?emailAddressProp wikibase:directClaim ?hasEmail.
 

--- a/queries/en_people.rq
+++ b/queries/en_people.rq
@@ -5,10 +5,10 @@ WHERE {
    # variables used in query
    BIND(wdt:P7 AS ?instanceOf).
    BIND(wdt:P76 AS ?hasName).
-   BIND(wdt:P24 AS ?donated).
-   BIND(wdt:P28 AS ?created).
-   BIND(wdt:P11 AS ?maintains).
-   BIND(wdt:P10 AS ?founded).
+   BIND(wdt:P24 AS ?hasDonor).
+   BIND(wdt:P28 AS ?hasCreator).
+   BIND(wdt:P11 AS ?hasMaintainer).
+   BIND(wdt:P10 AS ?hasFounder).
    BIND(wdt:P22 AS ?hasWebsite).
    BIND(wdt:P16 AS ?hasEmail).
    BIND(wd:Q21 AS ?human).
@@ -28,10 +28,10 @@ WHERE {
         FILTER(LANG(?personDescription) = ?langCode).
    }
 
-   ?donorProp wikibase:directClaim ?donated.
-   ?creatorProp wikibase:directClaim ?created.
-   ?maintainerProp wikibase:directClaim ?maintains.
-   ?founderProp wikibase:directClaim ?founded.
+   ?donorProp wikibase:directClaim ?hasDonor.
+   ?creatorProp wikibase:directClaim ?hasCreator.
+   ?maintainerProp wikibase:directClaim ?hasMaintainer.
+   ?founderProp wikibase:directClaim ?hasFounder.
    ?nameProp wikibase:directClaim ?hasName.
    ?officialWebsiteProp wikibase:directClaim ?hasWebsite.
    ?emailAddressProp wikibase:directClaim ?hasEmail.

--- a/queries/en_subjects.rq
+++ b/queries/en_subjects.rq
@@ -2,7 +2,7 @@ SELECT ?qid ?subjectLabel (COUNT(?collection) AS ?count)
 WHERE {
    # variables used in query
    BIND(wdt:P7 AS ?instanceOf).
-   BIND(wdt:P23 AS ?hasSubject)
+   BIND(wdt:P23 AS ?hasSubject).
    BIND(wd:Q85 AS ?ChinatownCollection).
    BIND("http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/" AS ?baseURI)
 

--- a/queries/en_subjects.rq
+++ b/queries/en_subjects.rq
@@ -1,14 +1,14 @@
 SELECT ?qid ?subjectLabel (COUNT(?collection) AS ?count)
 WHERE {
-   # properties used in query
+   # variables used in query
    BIND(wdt:P7 AS ?instanceOf).
    BIND(wdt:P23 AS ?hasSubject)
-   # items used in query
    BIND(wd:Q85 AS ?ChinatownCollection).
+   BIND("http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/" AS ?baseURI)
 
    ?collection ?instanceOf ?ChinatownCollection;
                ?hasSubject ?subject.
 
-   BIND(REPLACE(STR(?subject), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?qid).
+   BIND(REPLACE(STR(?subject), ?baseURI, "") AS ?qid).
    SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
 } GROUP BY ?qid ?subjectLabel ORDER BY DESC(?count)

--- a/queries/en_subjects.rq
+++ b/queries/en_subjects.rq
@@ -1,8 +1,14 @@
-SELECT ?title ?qid ?subjectLabel (COUNT(?collection) AS ?count)
+SELECT ?qid ?subjectLabel (COUNT(?collection) AS ?count)
 WHERE {
-   ?collection wdt:P7 wd:Q85;
-               wdt:P23 ?subject.
-   BIND("Subjects" as ?title).
+   # properties used in query
+   BIND(wdt:P7 AS ?instanceOf).
+   BIND(wdt:P23 AS ?hasSubject)
+   # items used in query
+   BIND(wd:Q85 AS ?ChinatownCollection).
+
+   ?collection ?instanceOf ?ChinatownCollection;
+               ?hasSubject ?subject.
+
    BIND(REPLACE(STR(?subject), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?qid).
    SERVICE wikibase:label { bd:serviceParam wikibase:language "en". }
-} GROUP BY ?title ?qid ?subjectLabel ORDER BY DESC(?count)
+} GROUP BY ?qid ?subjectLabel ORDER BY DESC(?count)

--- a/queries/zh_collections-by-maintainer.rq
+++ b/queries/zh_collections-by-maintainer.rq
@@ -1,6 +1,12 @@
 SELECT DISTINCT ?qid ?collectionLabel WHERE {
-  ?collection wdt:P7 wd:Q85;
-               wdt:P11 wd:{{.}}.
+  # variables used in query
+  BIND(wdt:P7 AS ?instanceOf).
+  BIND(wdt:P11 AS ?maintainedBy)
+  BIND(wd:Q85 AS ?ChinatownCollection).
+  BIND("http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/" AS ?baseURI).
+
+  ?collection ?instanceOf ?ChinatownCollection;
+               ?maintainedBy wd:{{.}}.
   SERVICE wikibase:label { bd:serviceParam wikibase:language "zh" }
-  BIND(REPLACE(STR(?collection), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?qid)
+  BIND(REPLACE(STR(?collection), ?baseURI, "") AS ?qid)
 } ORDER BY ?collectionLabel

--- a/queries/zh_collections-by-maintainer.rq
+++ b/queries/zh_collections-by-maintainer.rq
@@ -1,12 +1,12 @@
 SELECT DISTINCT ?qid ?collectionLabel WHERE {
   # variables used in query
   BIND(wdt:P7 AS ?instanceOf).
-  BIND(wdt:P11 AS ?maintainedBy)
+  BIND(wdt:P11 AS ?hasMaintainer).
   BIND(wd:Q85 AS ?ChinatownCollection).
   BIND("http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/" AS ?baseURI).
 
   ?collection ?instanceOf ?ChinatownCollection;
-               ?maintainedBy wd:{{.}}.
+               ?hasMaintainer wd:{{.}}.
   SERVICE wikibase:label { bd:serviceParam wikibase:language "zh" }
   BIND(REPLACE(STR(?collection), ?baseURI, "") AS ?qid)
 } ORDER BY ?collectionLabel

--- a/queries/zh_collections-by-material.rq
+++ b/queries/zh_collections-by-material.rq
@@ -1,6 +1,12 @@
 SELECT DISTINCT ?qid ?collectionLabel WHERE {
-  ?collection wdt:P7 wd:Q85;
-               wdt:P38 wd:{{.}}.
+  # variables used in query
+   BIND(wdt:P7 AS ?instanceOf).
+   BIND(wdt:P38 AS ?containsMaterial)
+   BIND(wd:Q85 AS ?ChinatownCollection).
+   BIND("http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/" AS ?baseURI).
+
+  ?collection ?instanceOf ?ChinatownCollection;
+              ?containsMaterial wd:{{.}}.
   SERVICE wikibase:label { bd:serviceParam wikibase:language "zh" }
-  BIND(REPLACE(STR(?collection), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?qid)
+  BIND(REPLACE(STR(?collection), ?baseURI, "") AS ?qid)
 } ORDER BY ?collectionLabel

--- a/queries/zh_collections-by-material.rq
+++ b/queries/zh_collections-by-material.rq
@@ -1,12 +1,12 @@
 SELECT DISTINCT ?qid ?collectionLabel WHERE {
   # variables used in query
    BIND(wdt:P7 AS ?instanceOf).
-   BIND(wdt:P38 AS ?containsMaterial)
+   BIND(wdt:P38 AS ?hasMaterial).
    BIND(wd:Q85 AS ?ChinatownCollection).
    BIND("http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/" AS ?baseURI).
 
   ?collection ?instanceOf ?ChinatownCollection;
-              ?containsMaterial wd:{{.}}.
+              ?hasMaterial wd:{{.}}.
   SERVICE wikibase:label { bd:serviceParam wikibase:language "zh" }
   BIND(REPLACE(STR(?collection), ?baseURI, "") AS ?qid)
 } ORDER BY ?collectionLabel

--- a/queries/zh_collections-by-subject.rq
+++ b/queries/zh_collections-by-subject.rq
@@ -1,6 +1,12 @@
 SELECT DISTINCT ?qid ?collectionLabel WHERE {
-  ?collection wdt:P7 wd:Q85;
-               wdt:P23 wd:{{.}}.
+   # variables used in query
+   BIND(wdt:P7 AS ?instanceOf).
+   BIND(wdt:P23 AS ?hasSubject)
+   BIND(wd:Q85 AS ?ChinatownCollection).
+   BIND("http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/" AS ?baseURI)
+
+  ?collection ?instanceOf ?ChinatownCollection;
+              ?hasSubject wd:{{.}}.
   SERVICE wikibase:label { bd:serviceParam wikibase:language "zh" }
-  BIND(REPLACE(STR(?collection), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?qid)
+  BIND(REPLACE(STR(?collection), ?baseURI, "") AS ?qid)
 } ORDER BY ?collectionLabel

--- a/queries/zh_collections-by-subject.rq
+++ b/queries/zh_collections-by-subject.rq
@@ -1,7 +1,7 @@
 SELECT DISTINCT ?qid ?collectionLabel WHERE {
    # variables used in query
    BIND(wdt:P7 AS ?instanceOf).
-   BIND(wdt:P23 AS ?hasSubject)
+   BIND(wdt:P23 AS ?hasSubject).
    BIND(wd:Q85 AS ?ChinatownCollection).
    BIND("http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/" AS ?baseURI)
 

--- a/queries/zh_collections.rq
+++ b/queries/zh_collections.rq
@@ -1,34 +1,64 @@
-SELECT DISTINCT ?langCode ?title ?qid ?collectionLabel ?collectionTypePropLabel ?collectionTypeLabel ?description ?descriptionPropLabel ?wdItemPropLabel ?wdItem ?describedAtURLPropLabel 
+SELECT DISTINCT ?langCode ?qid ?collectionLabel 
+?collectionTypePropLabel ?collectionTypeLabel ?description ?descriptionPropLabel ?wdItemPropLabel ?wdItem ?describedAtURLPropLabel 
 ?describedAtURL ?officialWebsitePropLabel ?officialWebsite ?creatorPropLabel ?creators ?maintainerPropLabel ?maintainers
 ?materialsStartPropLabel ?materialsEndPropLabel (YEAR(?materialsStart) as ?materialsStartYear) (YEAR(?materialsEnd) as ?materialsEndYear)
 ?digitizationStatusPropLabel ?digitizationStatusLabel ?accessStatusPropLabel ?accessStatusLabel 
 ?generalRecordsTypes ?generalRecordsPropLabel ?specificRecordsTypes ?specificRecordsPropLabel
-?subjects ?subjectPropLabel ?languages ?languagePropLabel ?collectionTitle ?collectionTitlePropLabel
+?subjects ?subjectPropLabel ?languages ?languagePropLabel ?collectionTitle ?collectionTitlePropLabel 
 ?accessPolicy ?accessPolicyPropLabel ?projectStatus ?projectStatusPropLabel
 ?projectStartPropLabel ?projectEndPropLabel (YEAR(?projectStart) as ?projectStartYear) (YEAR(?projectEnd) as ?projectEndYear)
 ?donors ?donorPropLabel
 WHERE {
-   ?collection wdt:P7 wd:Q85;
-               wdt:P27 ?collectionTitle.
-   BIND("馆藏" as ?title).
-   BIND("zh" as ?langCode).
-   BIND(REPLACE(STR(?collection), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?qid).
-   OPTIONAL{?collection wdt:P50 ?collectionType.}
-   OPTIONAL{?collection wdt:P37 ?description.
-            FILTER(LANG(?description) = "zh").}
-   OPTIONAL{?collection wdt:P33 ?wdItem.}
-   OPTIONAL{?collection wdt:P17 ?describedAtURL.}
-   OPTIONAL{?collection wdt:P22 ?officialWebsite.}
-   OPTIONAL{?collection wdt:P30 ?materialsStart.}
-   OPTIONAL{?collection wdt:P31 ?materialsEnd.}
-   OPTIONAL{?collection wdt:P40 ?digitizationStatus.}
-   OPTIONAL{?collection wdt:P32 ?accessStatus.}
-   OPTIONAL{?collection wdt:P41 ?accessPolicy.
-            FILTER(LANG(?accessPolicy) = "zh").}
-   OPTIONAL{?collection wdt:P42 ?projectStatus.
-            FILTER(LANG(?projectStatus) = "zh").}
-   OPTIONAL{?collection wdt:P43 ?projectStart.}
-   OPTIONAL{?collection wdt:P44 ?projectEnd.}
+  # variables used in query
+  BIND(wdt:P7 AS ?instanceOf).
+  BIND(wdt:P27 AS ?hasTitle).
+  BIND(wdt:P50 AS ?hasCollectionType).
+  BIND(wdt:P37 AS ?hasDescription).
+  BIND(wdt:P33 AS ?hasWikidataItem).
+  BIND(wdt:P17 AS ?hasDescriptionSite).
+  BIND(wdt:P22 AS ?hasWebsite).
+  BIND(wdt:P30 AS ?hasMaterialsStartDate).
+  BIND(wdt:P31 AS ?hasMaterialsEndDate).
+  BIND(wdt:P40 AS ?hasDigitizationStatus).
+  BIND(wdt:P32 AS ?hasAccessStatus).
+  BIND(wdt:P41 AS ?hasAccessPolicy).
+  BIND(wdt:P42 AS ?hasProjectStatus)
+  BIND(wdt:P43 AS ?hasProjectStartDate).
+  BIND(wdt:P44 AS ?hasProjectEndDate).
+  BIND(wdt:P28 AS ?hasCreator).
+  BIND(wdt:P11 AS ?hasMaintainer).
+  BIND(wdt:P38 AS ?hasGeneralRecordsType).
+  BIND(wdt:P48 AS ?hasSpecificRecordsType).
+  BIND(wdt:P23 AS ?hasSubject).
+  BIND(wdt:P13 AS ?hasLanguage).
+  BIND(wdt:P24 AS ?hasDonor).
+
+  BIND(wd:Q85 AS ?ChinatownCollection).
+  BIND("zh" as ?langCode).
+  BIND("http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/" AS ?baseURI).
+
+  ?collection ?instanceOf ?ChinatownCollection;
+              ?hasTitle ?collectionTitle.
+
+  FILTER(LANG(?collectionTitle) = ?langCode).
+   
+  BIND(REPLACE(STR(?collection), ?baseURI, "") AS ?qid).
+  OPTIONAL{?collection ?hasCollectionType ?collectionType.}
+  OPTIONAL{?collection ?hasDescription ?description.
+          FILTER(LANG(?description) = ?langCode).}
+  OPTIONAL{?collection ?hasWikidataItem ?wdItem.}
+  OPTIONAL{?collection ?hasDescriptionSite ?describedAtURL.}
+  OPTIONAL{?collection ?hasWebsite ?officialWebsite.}
+  OPTIONAL{?collection ?hasMaterialsStartDate ?materialsStart.}
+  OPTIONAL{?collection ?hasMaterialsEndDate ?materialsEnd.}
+  OPTIONAL{?collection ?hasDigitizationStatus ?digitizationStatus.}
+  OPTIONAL{?collection ?hasAccessStatus ?accessStatus.}
+  OPTIONAL{?collection ?hasAccessPolicy ?accessPolicy.
+            FILTER(LANG(?accessPolicy) = ?langCode).}
+   OPTIONAL{?collection ?hasProjectStatus ?projectStatus.
+            FILTER(LANG(?projectStatus) = ?langCode).}
+   OPTIONAL{?collection ?hasProjectStartDate ?projectStart.}
+   OPTIONAL{?collection ?hasProjectEndDate ?projectEnd.}
    SERVICE wikibase:label { bd:serviceParam wikibase:language "zh,en". 
       ?collection rdfs:label ?collectionLabel.
       ?collectionTitleProp rdfs:label ?collectionTitlePropLabel.
@@ -56,69 +86,69 @@ WHERE {
       ?projectEndProp rdfs:label ?projectEndPropLabel.
       ?donorProp rdfs:label ?donorPropLabel.
    }
-   ?wdItemProp wikibase:directClaim wdt:P33.
-   ?describedAtURLProp wikibase:directClaim wdt:P17.
-   ?officialWebsiteProp wikibase:directClaim wdt:P22.
-   ?creatorProp wikibase:directClaim wdt:P28.
-   ?maintainerProp wikibase:directClaim wdt:P11.
-   ?materialsStartProp wikibase:directClaim wdt:P30.
-   ?materialsEndProp wikibase:directClaim wdt:P31.
-   ?descriptionProp wikibase:directClaim wdt:P37.
-   ?collectionTypeProp wikibase:directClaim wdt:P50.
-   ?digitizationStatusProp wikibase:directClaim wdt:P40.
-   ?accessStatusProp wikibase:directClaim wdt:P32.
-   ?generalRecordsProp wikibase:directClaim wdt:P38.
-   ?specificRecordsProp wikibase:directClaim wdt:P48.
-   ?subjectProp wikibase:directClaim wdt:P23.
-   ?languageProp wikibase:directClaim wdt:P13.
-   ?collectionTitleProp wikibase:directClaim wdt:P27.
-   ?accessPolicyProp wikibase:directClaim wdt:P41.
-   ?projectStatusProp wikibase:directClaim wdt:P42.
-   ?projectStartProp wikibase:directClaim wdt:P43.
-   ?projectEndProp wikibase:directClaim wdt:P44.
-   ?donorProp wikibase:directClaim wdt:P24.
-   FILTER(LANG(?collectionTitle) = "zh").
-   {
-     SELECT ?innerCollection 
-            (group_concat(distinct ?generalRecordsLabel; separator="; ") as ?generalRecordsTypes)
-            (group_concat(distinct ?specificRecordsLabel; separator="; ") as ?specificRecordsTypes)
-            (group_concat(distinct ?subjectLabel; separator="; ") as ?subjects)
-            (group_concat(distinct ?languageLabel; separator="; ") as ?languages)
-            (group_concat(distinct ?creatorLink; separator="; ") as ?creators)
-            (group_concat(distinct ?maintainerLink; separator="; ") as ?maintainers)
-            (group_concat(distinct ?donorLink; separator="; ") as ?donors)
-     WHERE {
-       ?innerCollection wdt:P7 wd:Q85.
-       OPTIONAL{?innerCollection wdt:P38 ?generalRecords}
-       OPTIONAL{?innerCollection wdt:P48 ?specificRecords}
-       OPTIONAL{?innerCollection wdt:P23 ?subject}
-       OPTIONAL{?innerCollection wdt:P13 ?language}
-       OPTIONAL{?innerCollection wdt:P28 ?creator.
-         BIND(REPLACE(STR(?creator), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?creatorQid).
-         ?creator rdfs:label ?creatorLabel.
-         FILTER(LANG(?creatorLabel) = "zh").
-         BIND(CONCAT("<a href='./", STR(?creatorQid), ".html'>", STR(?creatorLabel), "</a>") AS ?creatorLink).
-       }
-       OPTIONAL{?innerCollection wdt:P11 ?maintainer.
-        BIND(REPLACE(STR(?maintainer), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?maintainerQid).
-        ?maintainer rdfs:label ?maintainerLabel.
-        FILTER(LANG(?maintainerLabel) = "zh").
-        BIND(CONCAT("<a href='./", STR(?maintainerQid), ".html'>", STR(?maintainerLabel), "</a>") AS ?maintainerLink).
-       }
-       OPTIONAL{?innerCollection wdt:P24 ?donor.
-        BIND(REPLACE(STR(?donor), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?donorQid).
-        ?donor rdfs:label ?donorLabel.
-        FILTER(LANG(?donorLabel) = "zh").
-        BIND(CONCAT("<a href='./", STR(?donorQid), ".html'>", STR(?donorLabel), "</a>") AS ?donorLink).
-       }
-       SERVICE wikibase:label { bd:serviceParam wikibase:language "zh,en". 
-          ?generalRecords rdfs:label ?generalRecordsLabel.
-          ?specificRecords rdfs:label ?specificRecordsLabel. 
-          ?subject rdfs:label ?subjectLabel.
-          ?language rdfs:label ?languageLabel.            
-       }
+  ?collectionTitleProp wikibase:directClaim ?hasTitle.
+  ?collectionTypeProp wikibase:directClaim ?hasCollectionType.
+  ?descriptionProp wikibase:directClaim ?hasDescription.
+  ?wdItemProp wikibase:directClaim ?hasWikidataItem.
+  ?describedAtURLProp wikibase:directClaim ?hasDescriptionSite.
+  ?officialWebsiteProp wikibase:directClaim ?hasWebsite.
+  ?materialsStartProp wikibase:directClaim ?hasMaterialsStartDate.
+  ?materialsEndProp wikibase:directClaim ?hasMaterialsEndDate.
+  ?digitizationStatusProp wikibase:directClaim ?hasDigitizationStatus.
+  ?accessStatusProp wikibase:directClaim ?hasAccessStatus.
+  ?accessPolicyProp wikibase:directClaim ?hasAccessPolicy.
+  ?projectStatusProp wikibase:directClaim ?hasProjectStatus.
+  ?projectStartProp wikibase:directClaim ?hasProjectStartDate.
+  ?projectEndProp wikibase:directClaim ?hasProjectEndDate.
+  ?creatorProp wikibase:directClaim ?hasCreator.
+  ?maintainerProp wikibase:directClaim ?hasMaintainer. 
+  ?generalRecordsProp wikibase:directClaim ?hasGeneralRecordsType.
+  ?specificRecordsProp wikibase:directClaim ?hasSpecificRecordsType.
+  ?subjectProp wikibase:directClaim ?hasSubject.
+  ?languageProp wikibase:directClaim ?hasLanguage.
+  ?donorProp wikibase:directClaim ?hasDonor.
+   
+  {
+    SELECT ?innerCollection 
+          (group_concat(distinct ?generalRecordsLabel; separator="; ") as ?generalRecordsTypes)
+          (group_concat(distinct ?specificRecordsLabel; separator="; ") as ?specificRecordsTypes)
+          (group_concat(distinct ?subjectLabel; separator="; ") as ?subjects)
+          (group_concat(distinct ?languageLabel; separator="; ") as ?languages)
+          (group_concat(distinct ?creatorLink; separator="; ") as ?creators)
+          (group_concat(distinct ?maintainerLink; separator="; ") as ?maintainers)
+          (group_concat(distinct ?donorLink; separator="; ") as ?donors)
+    WHERE {
+      ?innerCollection wdt:P7 wd:Q85.
+      OPTIONAL{?innerCollection wdt:P38 ?generalRecords}
+      OPTIONAL{?innerCollection wdt:P48 ?specificRecords}
+      OPTIONAL{?innerCollection wdt:P23 ?subject}
+      OPTIONAL{?innerCollection wdt:P13 ?language}
+      OPTIONAL{?innerCollection wdt:P28 ?creator.
+        BIND(REPLACE(STR(?creator), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?creatorQid).
+        ?creator rdfs:label ?creatorLabel.
+        FILTER(LANG(?creatorLabel) = "zh").
+        BIND(CONCAT("<a href='./", STR(?creatorQid), ".html'>", STR(?creatorLabel), "</a>") AS ?creatorLink).
       }
-     GROUP BY ?innerCollection
+      OPTIONAL{?innerCollection wdt:P11 ?maintainer.
+      BIND(REPLACE(STR(?maintainer), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?maintainerQid).
+      ?maintainer rdfs:label ?maintainerLabel.
+      FILTER(LANG(?maintainerLabel) = "zh").
+      BIND(CONCAT("<a href='./", STR(?maintainerQid), ".html'>", STR(?maintainerLabel), "</a>") AS ?maintainerLink).
+      }
+      OPTIONAL{?innerCollection wdt:P24 ?donor.
+      BIND(REPLACE(STR(?donor), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?donorQid).
+      ?donor rdfs:label ?donorLabel.
+      FILTER(LANG(?donorLabel) = "zh").
+      BIND(CONCAT("<a href='./", STR(?donorQid), ".html'>", STR(?donorLabel), "</a>") AS ?donorLink).
+      }
+      SERVICE wikibase:label { bd:serviceParam wikibase:language "zh,en". 
+        ?generalRecords rdfs:label ?generalRecordsLabel.
+        ?specificRecords rdfs:label ?specificRecordsLabel. 
+        ?subject rdfs:label ?subjectLabel.
+        ?language rdfs:label ?languageLabel.            
+      }
     }
-  FILTER(?innerCollection = ?collection)
+    GROUP BY ?innerCollection
+  }
+FILTER(?innerCollection = ?collection)
 } ORDER BY (?collectionLabel)

--- a/queries/zh_maintainers.rq
+++ b/queries/zh_maintainers.rq
@@ -1,7 +1,13 @@
 SELECT ?qid ?maintainerLabel (COUNT(?collection) AS ?count)
 WHERE {
-   ?collection wdt:P7 wd:Q85;
-               wdt:P11 ?maintainer.
+   # properties used in query
+   BIND(wdt:P7 AS ?instanceOf).
+   BIND(wdt:P11 AS ?maintainedBy)
+   # items used in query
+   BIND(wd:Q85 AS ?ChinatownCollection).
+
+   ?collection ?instanceOf ?ChinatownCollection;
+               ?maintainedBy ?maintainer.
    BIND(REPLACE(STR(?maintainer), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?qid).
-   SERVICE wikibase:label { bd:serviceParam wikibase:language "zh,en". }
+   SERVICE wikibase:label { bd:serviceParam wikibase:language "zh". }
 } GROUP BY ?qid ?maintainerLabel ORDER BY DESC(?count)

--- a/queries/zh_maintainers.rq
+++ b/queries/zh_maintainers.rq
@@ -2,12 +2,12 @@ SELECT ?qid ?maintainerLabel (COUNT(?collection) AS ?count)
 WHERE {
    # variables used in query
    BIND(wdt:P7 AS ?instanceOf).
-   BIND(wdt:P11 AS ?maintainedBy)
+   BIND(wdt:P11 AS ?hasMaintainer).
    BIND(wd:Q85 AS ?ChinatownCollection).
    BIND("http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/" AS ?baseURI).
 
    ?collection ?instanceOf ?ChinatownCollection;
-               ?maintainedBy ?maintainer.
+               ?hasMaintainer ?maintainer.
    BIND(REPLACE(STR(?maintainer), ?baseURI, "") AS ?qid).
    SERVICE wikibase:label { bd:serviceParam wikibase:language "zh". }
 } GROUP BY ?qid ?maintainerLabel ORDER BY DESC(?count)

--- a/queries/zh_maintainers.rq
+++ b/queries/zh_maintainers.rq
@@ -1,13 +1,13 @@
 SELECT ?qid ?maintainerLabel (COUNT(?collection) AS ?count)
 WHERE {
-   # properties used in query
+   # variables used in query
    BIND(wdt:P7 AS ?instanceOf).
    BIND(wdt:P11 AS ?maintainedBy)
-   # items used in query
    BIND(wd:Q85 AS ?ChinatownCollection).
+   BIND("http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/" AS ?baseURI).
 
    ?collection ?instanceOf ?ChinatownCollection;
                ?maintainedBy ?maintainer.
-   BIND(REPLACE(STR(?maintainer), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?qid).
+   BIND(REPLACE(STR(?maintainer), ?baseURI, "") AS ?qid).
    SERVICE wikibase:label { bd:serviceParam wikibase:language "zh". }
 } GROUP BY ?qid ?maintainerLabel ORDER BY DESC(?count)

--- a/queries/zh_materials.rq
+++ b/queries/zh_materials.rq
@@ -1,7 +1,13 @@
 SELECT ?qid ?materialLabel (COUNT(?collection) AS ?count)
 WHERE {
-   ?collection wdt:P7 wd:Q85;
-               wdt:P38 ?material.
+   # properties used in query
+   BIND(wdt:P7 AS ?instanceOf).
+   BIND(wdt:P38 AS ?containsMaterial)
+   # items used in query
+   BIND(wd:Q85 AS ?ChinatownCollection).
+
+   ?collection ?instanceOf ?ChinatownCollection;
+               ?containsMaterial ?material.
    BIND(REPLACE(STR(?material), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?qid).
    SERVICE wikibase:label { bd:serviceParam wikibase:language "zh". }
 } GROUP BY ?qid ?materialLabel ORDER BY DESC(?count)

--- a/queries/zh_materials.rq
+++ b/queries/zh_materials.rq
@@ -1,13 +1,13 @@
 SELECT ?qid ?materialLabel (COUNT(?collection) AS ?count)
 WHERE {
-   # properties used in query
+   # variables used in query
    BIND(wdt:P7 AS ?instanceOf).
    BIND(wdt:P38 AS ?containsMaterial)
-   # items used in query
    BIND(wd:Q85 AS ?ChinatownCollection).
+   BIND("http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/" AS ?baseURI).
 
    ?collection ?instanceOf ?ChinatownCollection;
                ?containsMaterial ?material.
-   BIND(REPLACE(STR(?material), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?qid).
+   BIND(REPLACE(STR(?material), ?baseURI, "") AS ?qid).
    SERVICE wikibase:label { bd:serviceParam wikibase:language "zh". }
 } GROUP BY ?qid ?materialLabel ORDER BY DESC(?count)

--- a/queries/zh_materials.rq
+++ b/queries/zh_materials.rq
@@ -2,12 +2,12 @@ SELECT ?qid ?materialLabel (COUNT(?collection) AS ?count)
 WHERE {
    # variables used in query
    BIND(wdt:P7 AS ?instanceOf).
-   BIND(wdt:P38 AS ?containsMaterial)
+   BIND(wdt:P38 AS ?hasMaterial).
    BIND(wd:Q85 AS ?ChinatownCollection).
    BIND("http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/" AS ?baseURI).
 
    ?collection ?instanceOf ?ChinatownCollection;
-               ?containsMaterial ?material.
+               ?hasMaterial ?material.
    BIND(REPLACE(STR(?material), ?baseURI, "") AS ?qid).
    SERVICE wikibase:label { bd:serviceParam wikibase:language "zh". }
 } GROUP BY ?qid ?materialLabel ORDER BY DESC(?count)

--- a/queries/zh_organizations.rq
+++ b/queries/zh_organizations.rq
@@ -1,29 +1,48 @@
-SELECT ?langCode ?title ?qid ?organizationLabel ?description ?wdItemPropLabel ?wdItem 
+SELECT ?langCode ?qid ?organizationLabel ?description ?wdItemPropLabel ?wdItem 
 ?officialWebsitePropLabel ?officialWebsite ?orgTypePropLabel ?orgTypeLabel 
 ?streetAddress ?streetAddressPropLabel (year(?inception) as ?inceptionYear) ?inceptionPropLabel  
 ?phoneNumber ?phoneNumberPropLabel ?emailAddress ?emailAddressPropLabel ?officialName ?officialNamePropLabel
 WHERE {
-   ?organization wdt:P7 wd:Q59;
-                 wdt:P26 ?officialName.
-   BIND("组织" as ?title).
+   # variables used in query
+   BIND(wdt:P7 AS ?instanceOf).
+   BIND(wdt:P26 AS ?hasOfficialName).
+   BIND(wdt:P37 AS ?hasDescription).
+   BIND(wdt:P51 AS ?hasType).
+   BIND(wdt:P33 AS ?hasWikidataItem).
+   BIND(wdt:P22 AS ?hasWebsite).
+   BIND(wdt:P29 AS ?hasStreetAddress).
+   BIND(wdt:P19 AS ?hasInceptionDate).
+   BIND(wdt:P25 AS ?hasPhoneNumber).
+   BIND(wdt:P16 AS ?hasEmail).
+
+   BIND(wd:Q59 AS ?organizationClass).
+
    BIND("zh" as ?langCode).
-   BIND(REPLACE(STR(?organization), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?qid).
-   OPTIONAL{?organization wdt:P37 ?description.}
-   OPTIONAL{?organization wdt:P51 ?orgType.}
-   OPTIONAL{?organization wdt:P33 ?wdItem.}
-   OPTIONAL{?organization wdt:P22 ?officialWebsite.}
-   OPTIONAL{?organization wdt:P29 ?streetAddress.}
-   OPTIONAL{?organization wdt:P19 ?inception.} 
-   OPTIONAL{?organization wdt:P25 ?phoneNumber.}
-   OPTIONAL{?organization wdt:P16 ?emailAddress.}
-   SERVICE wikibase:label { bd:serviceParam wikibase:language "zh,en". }
-   ?wdItemProp wikibase:directClaim wdt:P33.
-   ?officialWebsiteProp wikibase:directClaim wdt:P22.
-   ?orgTypeProp wikibase:directClaim wdt:P51.
-   ?streetAddressProp wikibase:directClaim wdt:P29. 
-   ?inceptionProp wikibase:directClaim wdt:P19.
-   ?phoneNumberProp wikibase:directClaim wdt:P25.
-   ?emailAddressProp wikibase:directClaim wdt:P16.
-   ?officialNameProp wikibase:directClaim wdt:P26.
-   FILTER(LANG(?officialName) = "zh").
+   BIND("http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/" AS ?baseURI).
+
+   ?organization ?instanceOf ?organizationClass;
+                 ?hasOfficialName ?officialName.
+   FILTER(LANG(?officialName) = ?langCode).
+
+   BIND(REPLACE(STR(?organization), ?baseURI, "") AS ?qid).
+
+   OPTIONAL{?organization ?hasDescription ?description.}
+   OPTIONAL{?organization ?hasType ?orgType.}
+   OPTIONAL{?organization ?hasWikidataItem ?wdItem.}
+   OPTIONAL{?organization ?hasWebsite ?officialWebsite.}
+   OPTIONAL{?organization ?hasStreetAddress ?streetAddress.}
+   OPTIONAL{?organization ?hasInceptionDate ?inception.} 
+   OPTIONAL{?organization ?hasPhoneNumber ?phoneNumber.}
+   OPTIONAL{?organization ?hasEmail ?emailAddress.}
+
+   ?officialNameProp wikibase:directClaim ?hasOfficialName.
+   ?orgTypeProp wikibase:directClaim ?hasType.
+   ?wdItemProp wikibase:directClaim ?hasWikidataItem.
+   ?officialWebsiteProp wikibase:directClaim ?hasWebsite.
+   ?streetAddressProp wikibase:directClaim ?hasStreetAddress. 
+   ?inceptionProp wikibase:directClaim ?hasInceptionDate.
+   ?phoneNumberProp wikibase:directClaim ?hasPhoneNumber.
+   ?emailAddressProp wikibase:directClaim ?hasEmail.
+   
+   SERVICE wikibase:label { bd:serviceParam wikibase:language "zh,en". } 
 } ORDER BY (?organizationLabel)

--- a/queries/zh_people.rq
+++ b/queries/zh_people.rq
@@ -9,7 +9,6 @@ WHERE {
    BIND(wdt:P28 AS ?created).
    BIND(wdt:P11 AS ?maintains).
    BIND(wdt:P10 AS ?founded).
-   BIND(wdt:P76 AS ?named).
    BIND(wdt:P22 AS ?hasWebsite).
    BIND(wdt:P16 AS ?hasEmail).
    BIND(wd:Q21 AS ?human).
@@ -33,7 +32,7 @@ WHERE {
    ?creatorProp wikibase:directClaim ?created.
    ?maintainerProp wikibase:directClaim ?maintains.
    ?founderProp wikibase:directClaim ?founded.
-   ?nameProp wikibase:directClaim ?named.
+   ?nameProp wikibase:directClaim ?hasName.
    ?officialWebsiteProp wikibase:directClaim ?hasWebsite.
    ?emailAddressProp wikibase:directClaim ?hasEmail.
 

--- a/queries/zh_people.rq
+++ b/queries/zh_people.rq
@@ -1,35 +1,53 @@
-SELECT ?langCode ?title ?qid ?personLabel ?createdCollections ?foundedOrganizations ?maintainsCollections ?donatedCollections
+SELECT ?langCode ?qid ?personLabel ?personDescription ?createdCollections ?foundedOrganizations ?maintainsCollections ?donatedCollections
 ?donorPropLabel ?creatorPropLabel ?maintainerPropLabel ?founderPropLabel
 ?name ?namePropLabel ?officialWebsite ?officialWebsitePropLabel ?emailAddress ?emailAddressPropLabel
 WHERE {
-   ?person wdt:P7 wd:Q21;
-        wdt:P76 ?name.
-   BIND("民众" as ?title).
+   # variables used in query
+   BIND(wdt:P7 AS ?instanceOf).
+   BIND(wdt:P76 AS ?hasName).
+   BIND(wdt:P24 AS ?donated).
+   BIND(wdt:P28 AS ?created).
+   BIND(wdt:P11 AS ?maintains).
+   BIND(wdt:P10 AS ?founded).
+   BIND(wdt:P76 AS ?named).
+   BIND(wdt:P22 AS ?hasWebsite).
+   BIND(wdt:P16 AS ?hasEmail).
+   BIND(wd:Q21 AS ?human).
    BIND("zh" as ?langCode).
-   BIND(REPLACE(STR(?person), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?qid).
-   SERVICE wikibase:label { bd:serviceParam wikibase:language "zh,en".
-        ?person rdfs:label ?personLabel.
-        ?donorProp rdfs:label ?donorPropLabel.
-        ?creatorProp rdfs:label ?creatorPropLabel.
-        ?maintainerProp rdfs:label ?maintainerPropLabel. 
-        ?founderProp rdfs:label ?founderPropLabel.
-        ?nameProp rdfs:label ?namePropLabel.
-        ?officialWebsiteProp rdfs:label ?officialWebsitePropLabel.
-        ?emailAddressProp rdfs:label ?emailAddressPropLabel.}
-   ?donorProp wikibase:directClaim wdt:P24.
-   ?creatorProp wikibase:directClaim wdt:P28.
-   ?maintainerProp wikibase:directClaim wdt:P11.
-   ?founderProp wikibase:directClaim wdt:P10.
-   ?nameProp wikibase:directClaim wdt:P76.
-   ?officialWebsiteProp wikibase:directClaim wdt:P22.
-   ?emailAddressProp wikibase:directClaim wdt:P16.
-   FILTER(LANG(?name) = "en").
+   BIND("http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/" AS ?baseURI)
+
+   ?person ?instanceOf ?human;
+        ?hasName ?name.
+   FILTER(LANG(?name) = ?langCode).
+   
+   BIND(REPLACE(STR(?person), ?baseURI, "") AS ?qid).
+
+   OPTIONAL{?person ?hasWebsite ?officialWebsite.}
+   OPTIONAL{?person ?hasEmail ?emailAddress.}
    OPTIONAL{
         ?person schema:description ?personDescription.
-        FILTER(LANG(?personDescription) = "zh").
+        FILTER(LANG(?personDescription) = ?langCode).
    }
-   OPTIONAL{?person wdt:P22 ?officialWebsite.}
-   OPTIONAL{?person wdt:P16 ?emailAddress.}
+
+   ?donorProp wikibase:directClaim ?donated.
+   ?creatorProp wikibase:directClaim ?created.
+   ?maintainerProp wikibase:directClaim ?maintains.
+   ?founderProp wikibase:directClaim ?founded.
+   ?nameProp wikibase:directClaim ?named.
+   ?officialWebsiteProp wikibase:directClaim ?hasWebsite.
+   ?emailAddressProp wikibase:directClaim ?hasEmail.
+
+   SERVICE wikibase:label { bd:serviceParam wikibase:language "zh,en". 
+     ?person rdfs:label ?personLabel.
+     ?donorProp rdfs:label ?donorPropLabel.
+     ?creatorProp rdfs:label ?creatorPropLabel.
+     ?maintainerProp rdfs:label ?maintainerPropLabel.
+     ?founderProp rdfs:label ?founderPropLabel.
+     ?nameProp rdfs:label ?namePropLabel.
+     ?officialWebsiteProp rdfs:label ?officialWebsitePropLabel.
+     ?emailAddressProp rdfs:label ?emailAddressPropLabel.
+   }
+
    {
      SELECT ?innerPerson
             (group_concat(distinct ?createdCollectionLink; separator="; ") as ?createdCollections)

--- a/queries/zh_people.rq
+++ b/queries/zh_people.rq
@@ -5,10 +5,10 @@ WHERE {
    # variables used in query
    BIND(wdt:P7 AS ?instanceOf).
    BIND(wdt:P76 AS ?hasName).
-   BIND(wdt:P24 AS ?donated).
-   BIND(wdt:P28 AS ?created).
-   BIND(wdt:P11 AS ?maintains).
-   BIND(wdt:P10 AS ?founded).
+   BIND(wdt:P24 AS ?hasDonor).
+   BIND(wdt:P28 AS ?hasCreator).
+   BIND(wdt:P11 AS ?hasMaintainer).
+   BIND(wdt:P10 AS ?hasFounder).
    BIND(wdt:P22 AS ?hasWebsite).
    BIND(wdt:P16 AS ?hasEmail).
    BIND(wd:Q21 AS ?human).
@@ -28,10 +28,10 @@ WHERE {
         FILTER(LANG(?personDescription) = ?langCode).
    }
 
-   ?donorProp wikibase:directClaim ?donated.
-   ?creatorProp wikibase:directClaim ?created.
-   ?maintainerProp wikibase:directClaim ?maintains.
-   ?founderProp wikibase:directClaim ?founded.
+   ?donorProp wikibase:directClaim ?hasDonor.
+   ?creatorProp wikibase:directClaim ?hasCreator.
+   ?maintainerProp wikibase:directClaim ?hasMaintainer.
+   ?founderProp wikibase:directClaim ?hasFounder.
    ?nameProp wikibase:directClaim ?hasName.
    ?officialWebsiteProp wikibase:directClaim ?hasWebsite.
    ?emailAddressProp wikibase:directClaim ?hasEmail.
@@ -46,7 +46,7 @@ WHERE {
      ?officialWebsiteProp rdfs:label ?officialWebsitePropLabel.
      ?emailAddressProp rdfs:label ?emailAddressPropLabel.
    }
-
+     
    {
      SELECT ?innerPerson
             (group_concat(distinct ?createdCollectionLink; separator="; ") as ?createdCollections)
@@ -54,7 +54,7 @@ WHERE {
             (group_concat(distinct ?maintainsCollectionLink; separator="; ") as ?maintainsCollections)
             (group_concat(distinct ?donatedCollectionLink; separator="; ") as ?donatedCollections)
      WHERE {
-       ?innerPerson wdt:P7 wd:Q21.
+       ?innerPerson ?instanceOf ?human.
        OPTIONAL{?innerPerson ^wdt:P28 ?createdCollection.
                BIND(REPLACE(STR(?createdCollection), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?createdCollectionQid).
                ?createdCollection rdfs:label ?createdCollectionLabel.
@@ -71,7 +71,7 @@ WHERE {
                FILTER(LANG(?maintainsCollectionLabel) = "zh").
                BIND(CONCAT("<a href='./", STR(?maintainsCollectionQid), ".html'>", STR(?maintainsCollectionLabel), "</a>") AS ?maintainsCollectionLink)
                }
-        OPTIONAL{?innerPerson ^wdt:P24 ?donatedCollection.
+       OPTIONAL{?innerPerson ^wdt:P24 ?donatedCollection.
                BIND(REPLACE(STR(?donatedCollection), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?donatedCollectionQid).
                ?donatedCollection rdfs:label ?donatedCollectionLabel.
                FILTER(LANG(?donatedCollectionLabel) = "zh").

--- a/queries/zh_subjects.rq
+++ b/queries/zh_subjects.rq
@@ -2,7 +2,7 @@ SELECT ?qid ?subjectLabel (COUNT(?collection) AS ?count)
 WHERE {
    # variables used in query
    BIND(wdt:P7 AS ?instanceOf).
-   BIND(wdt:P23 AS ?hasSubject)
+   BIND(wdt:P23 AS ?hasSubject).
    BIND(wd:Q85 AS ?ChinatownCollection).
    BIND("http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/" AS ?baseURI)
 

--- a/queries/zh_subjects.rq
+++ b/queries/zh_subjects.rq
@@ -1,8 +1,14 @@
-SELECT ?title ?qid ?subjectLabel (COUNT(?collection) AS ?count)
+SELECT ?qid ?subjectLabel (COUNT(?collection) AS ?count)
 WHERE {
-   ?collection wdt:P7 wd:Q85;
-               wdt:P23 ?subject.
-   BIND("Subjects" as ?title).
+   # properties used in query
+   BIND(wdt:P7 AS ?instanceOf).
+   BIND(wdt:P23 AS ?hasSubject)
+   # items used in query
+   BIND(wd:Q85 AS ?ChinatownCollection).
+
+   ?collection ?instanceOf ?ChinatownCollection;
+               ?hasSubject ?subject.
+
    BIND(REPLACE(STR(?subject), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?qid).
    SERVICE wikibase:label { bd:serviceParam wikibase:language "zh". }
-} GROUP BY ?title ?qid ?subjectLabel ORDER BY DESC(?count)
+} GROUP BY ?qid ?subjectLabel ORDER BY DESC(?count)

--- a/queries/zh_subjects.rq
+++ b/queries/zh_subjects.rq
@@ -1,14 +1,14 @@
 SELECT ?qid ?subjectLabel (COUNT(?collection) AS ?count)
 WHERE {
-   # properties used in query
+   # variables used in query
    BIND(wdt:P7 AS ?instanceOf).
    BIND(wdt:P23 AS ?hasSubject)
-   # items used in query
    BIND(wd:Q85 AS ?ChinatownCollection).
+   BIND("http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/" AS ?baseURI)
 
    ?collection ?instanceOf ?ChinatownCollection;
                ?hasSubject ?subject.
 
-   BIND(REPLACE(STR(?subject), "http://ec2-34-227-69-60.compute-1.amazonaws.com/entity/", "") AS ?qid).
+   BIND(REPLACE(STR(?subject), ?baseURI, "") AS ?qid).
    SERVICE wikibase:label { bd:serviceParam wikibase:language "zh". }
 } GROUP BY ?qid ?subjectLabel ORDER BY DESC(?count)

--- a/templates/collection.html
+++ b/templates/collection.html
@@ -67,7 +67,7 @@
 </div>
 <div class="row">
     <div class="col-6 mx-auto">
-        <a role="button" class="btn btn-primary" href='./collections.html'>{{ .title }}</a>
+        <a role="button" class="btn btn-primary" href='./collections.html'>{{if eq .langCode.String "en" }}Collections{{ else }}馆藏{{ end }}</a>
     </div>
 </div>
 {{ end }}

--- a/templates/collections_index.html
+++ b/templates/collections_index.html
@@ -1,10 +1,10 @@
 {{if eq (index . 0).langCode.String "en" }}{{ template "en_base" . }}{{ else }}{{ template "zh_base" . }}{{ end }}
-{{ define "title" }}{{ (index . 0).title}}{{ end }}
+{{ define "title" }}{{if eq (index . 0).langCode.String "en" }}Collections{{ else }}馆藏{{ end }}{{ end }}
 
 {{ define "content" }}
 <div class="row">
     <div class="col-10">
-        <h1>{{ (index . 0).title}}</h1>
+        <h1>{{if eq (index . 0).langCode.String "en" }}Collections{{ else }}馆藏{{ end }}</h1>
     </div>
     <div class="col-2">
         {{ if eq (index . 0).langCode.String "en" }}

--- a/templates/org_index.html
+++ b/templates/org_index.html
@@ -1,10 +1,10 @@
 {{if eq (index . 0).langCode.String "en" }}{{ template "en_base" . }}{{ else }}{{ template "zh_base" . }}{{ end }}
-{{ define "title" }}{{ (index . 0).title}}{{ end }}
+{{ define "title" }}{{if eq (index . 0).langCode.String "en" }}Organizations{{ else }}组织{{ end }}{{ end }}
 
 {{ define "content" }}
 <div class="row">
     <div class="col-10">
-        <h1>{{ (index . 0).title}}</h1>
+        <h1>{{if eq (index . 0).langCode.String "en" }}Organizations{{ else }}组织{{ end }}</h1>
     </div>
     <div class="col-2">
         {{ if eq (index . 0).langCode.String "en" }}

--- a/templates/organization.html
+++ b/templates/organization.html
@@ -30,7 +30,7 @@
 </dl>
 <div class="row">
     <div class="col-6 mx-auto">
-        <a role="button" class="btn btn-primary" href='./organizations.html'>{{ .title }}</a>
+        <a role="button" class="btn btn-primary" href='./organizations.html'>{{if eq .langCode.String "en" }}Organizations{{ else }}组织{{ end }}</a>
     </div>
 </div>
 {{ end }}

--- a/templates/people_index.html
+++ b/templates/people_index.html
@@ -1,10 +1,14 @@
 {{if eq (index . 0).langCode.String "en" }}{{ template "en_base" . }}{{ else }}{{ template "zh_base" . }}{{ end }}
-{{ define "title" }}{{ (index . 0).title}}{{ end }}
+{{ define "title" }}{{if eq (index . 0).langCode.String "en" }}People{{ else }}人员{{ end }}{{ end }}
 
 {{ define "content" }}
 <div class="row">
     <div class="col-10">
-        <h1>{{ (index . 0).title}}</h1>
+        {{ if eq (index . 0).langCode.String "en" }}
+            <h1>People</h1>
+        {{ else }}
+            <h1>人员</h1>
+        {{ end }}
     </div>
     <div class="col-2">
         {{ if eq (index . 0).langCode.String "en" }}

--- a/templates/person.html
+++ b/templates/person.html
@@ -43,7 +43,7 @@
 </dl>
 <div class="row">
     <div class="col-6 mx-auto">
-        <a role="button" class="btn btn-primary" href='./people.html'>{{ .title }}</a>
+        <a role="button" class="btn btn-primary" href='./people.html'>{{if eq .langCode.String "en" }}People{{ else }}人员{{ end }}</a>
     </div>
 </div>
 {{ end }}


### PR DESCRIPTION
Rewrite queries with properties/items bound to variables to make main body of query more readable (and hopefully easier to modify if PIDs and QIDs changed in the future). Note that subqueries still use literal values--need to read more about scoping to figure out how to make those work.